### PR TITLE
NEW: --open option

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ before_script:
   - phpenv rehash
   - export PATH=~/.composer/vendor/bin:$PATH
   - composer validate
-  - if [[ $PHPCS_TEST ]]; then composer global require squizlabs/php_codesniffer:^3 --prefer-dist --no-interaction --no-progress --no-suggest -o; fi
+  - if [[ $PHPCS_TEST ]]; then composer require squizlabs/php_codesniffer:^3 --no-update --prefer-dist --dev; fi
   - composer require --prefer-dist --no-update silverstripe/recipe-core:1.x-dev
   - composer install --prefer-dist
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ before_script:
   - export PATH=~/.composer/vendor/bin:$PATH
   - composer validate
   - if [[ $PHPCS_TEST ]]; then composer global require squizlabs/php_codesniffer:^3 --prefer-dist --no-interaction --no-progress --no-suggest -o; fi
-  - composer require --prefer-dist --no-update silverstripe/recipe-core:1.0.x-dev
+  - composer require --prefer-dist --no-update silverstripe/recipe-core:1.x-dev
   - composer install --prefer-dist
 
 script:

--- a/bin/serve
+++ b/bin/serve
@@ -20,7 +20,7 @@ foreach ($paths as $path) {
 }
 
 // Parse command-line options and env vars
-$options = getopt(null, [ 'host:', 'port:', 'hash:', 'bootstrap-file:' ]);
+$options = getopt(null, [ 'host:', 'port:', 'hash:', 'bootstrap-file:', 'open' ]);
 
 if (!empty($options['host'])) {
 	$host = $options['host'];
@@ -57,4 +57,10 @@ $server = $factory->launchServer([
 ]);
 
 print "Server running at " . $server->getURL() . " for "  . $path . "...\n";
+
+if (isset($options['open'])) {
+    $CLI_url = escapeshellarg($server->getURL());
+    echo `open $CLI_url`;
+}
+
 $server->passthru();

--- a/bin/serve
+++ b/bin/serve
@@ -58,9 +58,33 @@ $server = $factory->launchServer([
 
 print "Server running at " . $server->getURL() . " for "  . $path . "...\n";
 
+// Check if the user wants to open the page in their browser
 if (isset($options['open'])) {
-    $CLI_url = escapeshellarg($server->getURL());
-    echo `open $CLI_url`;
+    // Simple function to detect if a command exists on *nix system
+    $command_exist = function($cmd) {
+        $return = shell_exec(sprintf("which %s", escapeshellarg($cmd)));
+        return !empty($return);
+    };
+
+    // Pick which command to use
+    $cmd = '';
+    if (strtoupper(substr(PHP_OS, 0, 3)) === 'WIN') {
+        // Windows
+        $cmd = 'start';
+    } else if ($command_exist('xdg-open')) {
+        // Linux
+        $cmd = 'xdg-open';
+    } else if ($command_exist('open')) {
+        // MacOS
+        $cmd = 'open';
+    }
+
+    if ($cmd) {
+        $CLI_url = escapeshellarg($server->getURL());
+        echo `$cmd $CLI_url`;
+    } else {
+        echo "Could not identify the command to open a URL on you operating system.\n";
+    }
 }
 
 $server->passthru();

--- a/composer.json
+++ b/composer.json
@@ -26,6 +26,6 @@
     "minimum-stability": "dev",
     "prefer-stable": true,
     "scripts": {
-        "lint": "phpcs --standard=PSR2 code/ bin/ tests/"
+        "lint": "vendor/bin/phpcs --standard=PSR2 code/ bin/ tests/"
     }
 }

--- a/readme.md
+++ b/readme.md
@@ -20,10 +20,9 @@ $ vendor/bin/serve --host 127.0.0.1 --port 8000
 
 ![](serve.gif)
 
-## Opening a browser (OS X only)
+## Opening a browser
 
-If you are running OS X (or anything that has an `open` binary), you can
-add the `--open` argument to open a new browser window with the new server
+You can add the `--open` argument to open a new browser window with the new server.
 
 ```sh
 $ vendor/bin/serve --open

--- a/readme.md
+++ b/readme.md
@@ -20,6 +20,16 @@ $ vendor/bin/serve --host 127.0.0.1 --port 8000
 
 ![](serve.gif)
 
+## Opening a browser (OS X only)
+
+If you are running OS X (or anything that has an `open` binary), you can
+add the `--open` argument to open a new browser window with the new server
+
+```sh
+$ vendor/bin/serve --open
+```
+
+
 ## Including a bootstrap file
 
 The bootstrap-file argument lets you include a custom PHP file after


### PR DESCRIPTION
The --open option on the CLI script will call `open URL` in the user’s
shell.

In OS X, this will open the new site in a browser window.