### PR TITLE
PHPUnit should be dev dep

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,10 +3,12 @@
     "description": "Connects the PHP development server to SilverStripe",
     "license": "MIT",
     "require": {
-        "php": "^5.4|^7.0",
+        "php": "^5.4||^7.0",
         "symfony/process": "^3.0",
-        "silverstripe/framework": ">=3.2@dev",
-        "phpunit/phpunit": "^4.8"
+        "silverstripe/framework": ">=3.2@dev"
+    },
+    "require-dev": {
+    	"phpunit/phpunit": "^4.8 || ^5.7"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
This prevents other projects running new versions of `PHPUnit`. I can't see any dependency on `PHPUnit` other than for running the test suite.