### PR TITLE
BUG Fix serve serving static assets from wrong folder

### DIFF
--- a/bin/serve
+++ b/bin/serve
@@ -46,7 +46,9 @@ if (!empty($options['bootstrap-file'])) {
 	$bootstrapFile = null;
 }
 
-$factory = new SilverStripe\Serve\ServerFactory();
+$path = defined('PUBLIC_PATH') ? PUBLIC_PATH : BASE_PATH;
+
+$factory = new SilverStripe\Serve\ServerFactory($path);
 
 $server = $factory->launchServer([
     'preferredPort' => $port,
@@ -54,5 +56,5 @@ $server = $factory->launchServer([
     'bootstrapFile' => $bootstrapFile,
 ]);
 
-print "Server running at " . $server->getURL() . " for "  . BASE_PATH . "...\n";
+print "Server running at " . $server->getURL() . " for "  . $path . "...\n";
 $server->passthru();

--- a/code/constants-compat.php
+++ b/code/constants-compat.php
@@ -1,0 +1,11 @@
+<?php
+
+// Shiv in PUBLIC_PATH for pre-4.1
+if (!defined('PUBLIC_PATH')) {
+    define(
+        'PUBLIC_PATH',
+        file_exists(BASE_PATH . DIRECTORY_SEPARATOR . 'public')
+            ? (BASE_PATH . DIRECTORY_SEPARATOR . 'public')
+            : BASE_PATH
+    );
+}

--- a/code/constants.php
+++ b/code/constants.php
@@ -1,6 +1,5 @@
 <?php
 
-
 // Serve always hosts from the root
 define('BASE_URL', '');
 

--- a/code/server-handler.php
+++ b/code/server-handler.php
@@ -10,6 +10,7 @@ use SilverStripe\Core\Environment;
 
 require_once 'constants.php';
 require_once BASE_PATH . '/vendor/autoload.php';
+require_once 'constants-compat.php';
 
 // Include a bootstrap file (e.g. if you need extra settings to get a module started)
 if (Environment::getEnv('SERVE_BOOTSTRAP_FILE')) {
@@ -20,7 +21,7 @@ $uri = urldecode(
     parse_url($_SERVER['REQUEST_URI'], PHP_URL_PATH)
 );
 
-if ($uri !== "/" && file_exists(BASE_PATH . $uri) && !is_dir(BASE_PATH . $uri)) {
+if ($uri !== "/" && file_exists(PUBLIC_PATH . $uri) && !is_dir(PUBLIC_PATH . $uri)) {
     return false;
 }
 


### PR DESCRIPTION
Fixes behat test failures when serve is started in BASE_PATH instead of PUBLIC_PATH

Also see https://github.com/silverstripe/silverstripe-framework/pull/7755, although the framework PR isn't explicitly required for this change.