### PR TITLE
Using exec explicitly breaks CMD compat

### DIFF
--- a/code/ServerFactory.php
+++ b/code/ServerFactory.php
@@ -51,7 +51,7 @@ class ServerFactory
             ' -t ' . escapeshellarg($this->path) . ' ' .
             escapeshellarg($base . '/server-handler.php');
         if(\DIRECTORY_SEPARATOR !== '\\') {
-            $command = "exec ";
+            $command .= "exec ";
         }
 
         if (!empty($options['bootstrapFile'])) {

--- a/code/ServerFactory.php
+++ b/code/ServerFactory.php
@@ -46,10 +46,13 @@ class ServerFactory
         $port = PortChecker::findNextAvailablePort($host, $options['preferredPort']);
 
         $base = __DIR__;
-        $command = "exec " . escapeshellcmd($bin) .
+        $command = escapeshellcmd($bin) .
             ' -S ' . escapeshellarg($host . ':' . $port) .
             ' -t ' . escapeshellarg($this->path) . ' ' .
             escapeshellarg($base . '/server-handler.php');
+        if(\DIRECTORY_SEPARATOR !== '\\') {
+            $command = "exec ";
+        }
 
         if (!empty($options['bootstrapFile'])) {
             $command = "SERVE_BOOTSTRAP_FILE=" . escapeshellarg($options['bootstrapFile']) . " $command";


### PR DESCRIPTION
Using `exec` doesn't work on windows as exec is not a valid CMD command. This fixes #11. 

Also a validation for directory separator was added to mantain *nix shells. (This is actually a Symphony's `Process` class related issue)