### PR TITLE
DEP Upgrade installer dependencies

### DIFF
--- a/code/Server.php
+++ b/code/Server.php
@@ -94,7 +94,7 @@ class Server
             throw new LogicException("Server already started; cannot start a 2nd time");
         }
 
-        $this->process = new Process($this->command);
+        $this->process = Process::fromShellCommandline($this->command);
         $this->process->setTimeout(null);
         $this->process->start();
 

--- a/composer.json
+++ b/composer.json
@@ -4,12 +4,12 @@
     "license": "MIT",
     "require": {
         "php": "^8.1",
-        "symfony/process": "^4.0",
+        "symfony/process": "^6.1.3",
         "silverstripe/framework": "^5"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.5",
-        "squizlabs/php_codesniffer": "^3"
+        "squizlabs/php_codesniffer": "^3.7"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
### Description
'Passing a command as string when creating a `Process` class instance is deprecated since Symfony 4.2, pass it as an array of its arguments instead, or use the `"Process::fromShellCommandline()"` constructor if you need features provided by the shell.'

### Parent issue
- https://github.com/silverstripe/silverstripe-installer/issues/335